### PR TITLE
Fixed RCE on makedeb

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,10 +99,7 @@ function getTempBuildDir(packageName, version) {
 function tarDir(dir) {
     var archiveName = path.basename(dir) +'.orig.tar.xz';
     var archivePath = path.join(path.dirname(dir), archiveName);
-    
-    var cmd = 'tar cfJ '+ archivePath +' '+ dir;
-    cmd = cmd.split(' ');
-    return exec(cmd[0], cmd.slice(1));
+    return exec('tar', ['cfJ', archivePath, dir]);
 }
 
 // Write the required files into the DEBIAN directory.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var exec = require('child_process').exec;
+var exec = require('child_process').execFile;
 var fse = require('fs-extra');
 var path = require('path');
 var Promise = require('bluebird');
@@ -99,8 +99,10 @@ function getTempBuildDir(packageName, version) {
 function tarDir(dir) {
     var archiveName = path.basename(dir) +'.orig.tar.xz';
     var archivePath = path.join(path.dirname(dir), archiveName);
-
-    return exec('tar cfJ '+ archivePath +' '+ dir);
+    
+    var cmd = 'tar cfJ '+ archivePath +' '+ dir;
+    cmd = cmd.split(' ');
+    return exec(cmd[0], cmd.slice(1));
 }
 
 // Write the required files into the DEBIAN directory.
@@ -122,7 +124,9 @@ function writeDebianFiles(tempBuildDir, options) {
 
 // Run dpkg to make the .deb file.
 function dpkg(tempBuildDir) {
-    return exec('dpkg -b '+ tempBuildDir);
+    var cmd = 'dpkg -b '+ tempBuildDir;
+    cmd = cmd.split(' ');
+    return exec(cmd[0], cmd.slice(1));
 }
 
 module.exports = makeDeb;

--- a/index.js
+++ b/index.js
@@ -121,9 +121,7 @@ function writeDebianFiles(tempBuildDir, options) {
 
 // Run dpkg to make the .deb file.
 function dpkg(tempBuildDir) {
-    var cmd = 'dpkg -b '+ tempBuildDir;
-    cmd = cmd.split(' ');
-    return exec(cmd[0], cmd.slice(1));
+    return exec('dpkg', ['-b', tempBuildDir]);
 }
 
 module.exports = makeDeb;


### PR DESCRIPTION
### 📊 Metadata *

Command injection vulnerability 
#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-makedeb

### ⚙️ Description *

The makedeb module is vulnerable against RCE since a command is crafted using user inputs not validated and then executed, leading to arbitrary command injection. The argument options can be controlled by users without any sanitization. It was using `exec()` function which is vulnerable to **Command Injection** if it accepts user input and it goes through any sanitization or escaping.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Install the package and run the below code,:
```javascript
var makedeb = require('makedeb');
makedeb({ packageName: 'sample; touch HACKED; #', version: '1.2.3', 'buildDir':'.', 'installPath':process.cwd()});
```
A file named `HACKED` will be created in the current working directory.


### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

### 👍 User Acceptance Testing (UAT)

Only `execFile` is used, no breaking changes introduced.
